### PR TITLE
Fix #10

### DIFF
--- a/src/SqlLocalDb.msbuild
+++ b/src/SqlLocalDb.msbuild
@@ -166,12 +166,14 @@
     <!--
       Covert the code coverage output files to a single combined XML file.
     -->
-    <PropertyGroup>
-      <CodeCoverageTool Condition="'$(CodeCoverageTool)' == ''">$(VSPath)..\..\Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe</CodeCoverageTool>
+    <PropertyGroup Condition="'$(CodeCoverageTool)' == ''">
+      <CodeCoverageTool>$(VSPath)..\..\Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe</CodeCoverageTool>
+      <CodeCoverageTool Condition="!Exists('$(CodeCoverageTool)')">$(VS120COMNTOOLS)..\..\Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe</CodeCoverageTool>
     </PropertyGroup>
     <Error Condition="'$(EnableCodeCoverage)' == 'true' and '@(CodeCoverageData->Count())' == 0" Text="No code coverage files were produced." />
-    <Message Condition="'$(EnableCodeCoverage)' == 'true' and Exists('$(CodeCoverageTool)')" Text="Converting code coverage data to XML..." Importance="high" />
-    <Exec Condition="'$(EnableCodeCoverage)' == 'true' and Exists('$(CodeCoverageTool)') and '@(CodeCoverageData->Count())' > 0" Command="%22$(CodeCoverageTool)%22 analyze %22/output:$(CodeCoverageXml)%22 @(CodeCoverageData->'%22%(fullpath)%22', ' ')" />
+    <Error Condition="'$(EnableCodeCoverage)' == 'true' and !Exists('$(CodeCoverageTool)')" Text="Code coverage tool '$(CodeCoverageTool)' could not be found." />
+    <Message Condition="'$(EnableCodeCoverage)' == 'true'" Text="Converting code coverage data to XML..." Importance="high" />
+    <Exec Condition="'$(EnableCodeCoverage)' == 'true' and '@(CodeCoverageData->Count())' > 0" Command="%22$(CodeCoverageTool)%22 analyze %22/output:$(CodeCoverageXml)%22 @(CodeCoverageData->'%22%(fullpath)%22', ' ')" />
     <!--
       Add coveragexml file as artifact for AppVeyor CI builds.
     -->


### PR DESCRIPTION
Fix #10 by falling back to Visual Studio 2013's version of ```CodeCoverage.exe``` if the 2015 version cannot be found. Raise an MSBuild error if the tool cannot be found at all.