### PR TITLE
Re-enable Code Coverage

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 version: 1.15.{build}.0
 
 environment:
-  EnableCodeCoverage: false
   CoverallsRepoToken:
     secure: t/5ID5XZAyFKZNmgVJIrcs2Ah7Bn1Kr2cmAZcmEbvl/lGHHl6F4sxSLHK89z7I7E
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,10 +47,3 @@ deploy:
     skip_symbols: false
     on:
       appveyor_repo_tag: true
-
-  - provider: NuGet
-    server: https://ci.appveyor.com/nuget/martincostello-9fmhxpne2mas/api/v2/package
-    api_key:
-      secure: LiR+w6IXAHDke0ybiPQQkWSypbzpsIHCPjFVJFWwEog=
-    artifact: /.*\.nupkg/
-    skip_symbols: false

--- a/src/SqlLocalDb.runsettings
+++ b/src/SqlLocalDb.runsettings
@@ -5,7 +5,7 @@
   </RunConfiguration>
   <DataCollectionRunSettings>
     <DataCollectors>
-      <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
         <Configuration>
           <CodeCoverage>
             <CollectAspDotNet>False</CollectAspDotNet>


### PR DESCRIPTION
Re-enables code coverage for AppVeyor CI builds. Also removes explicit push to AppVeyor CI NuGet feed.