### PR TITLE
Fix issue 19

### DIFF
--- a/src/SqlLocalDb.Coverage.runsettings
+++ b/src/SqlLocalDb.Coverage.runsettings
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <ResultsDirectory>.\TestResults</ResultsDirectory>
+  </RunConfiguration>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+        <Configuration>
+          <CodeCoverage>
+            <CollectAspDotNet>False</CollectAspDotNet>
+            <CollectFromChildProcesses>False</CollectFromChildProcesses>
+            <ModulePaths>
+              <Exclude>
+                <ModulePath>.*appveyor.*</ModulePath>
+                <ModulePath>.*ATL.*</ModulePath>
+                <ModulePath>.*CPPUnitTestFramework.*</ModulePath>
+                <ModulePath>.*MSVC.*</ModulePath>
+                <ModulePath>.*Tests.*</ModulePath>
+              </Exclude>
+            </ModulePaths>
+            <Attributes>
+              <Exclude>
+                <Attribute>^System.CodeDom.Compiler.GeneratedCodeAttribute$</Attribute>
+                <Attribute>^System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute$</Attribute>
+                <Attribute>^System.Diagnostics.DebuggerHiddenAttribute$</Attribute>
+                <Attribute>^System.Diagnostics.DebuggerNonUserCodeAttribute$</Attribute>
+                <Attribute>^System.Runtime.CompilerServices.CompilerGeneratedAttribute$</Attribute>
+              </Exclude>
+            </Attributes>
+          </CodeCoverage>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/src/SqlLocalDb.msbuild
+++ b/src/SqlLocalDb.msbuild
@@ -130,7 +130,10 @@
       <_IsVSEnterprise Condition="'$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\VisualStudio\14.0\Setup\vs\Enterprise@ProductDir)' != ''">true</_IsVSEnterprise>
       <_IsVSEnterprise Condition="'$(_IsVSEnterprise)' == '' and '$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\14.0\Setup\vs\Enterprise@ProductDir)' != ''">true</_IsVSEnterprise>
       <_IsVSEnterprise Condition="'$(_IsVSEnterprise)' == ''">false</_IsVSEnterprise>
-      <EnableCodeCoverage Condition="'$(EnableCodeCoverage)' == '' and '$(_IsVSEnterprise)' == 'true'">true</EnableCodeCoverage>
+      <!--
+        AppVeyor has Visual Studio Test Agents installed, so can provide code coverage.
+      -->
+      <EnableCodeCoverage Condition="'$(EnableCodeCoverage)' == '' and ('$(_IsVSEnterprise)' == 'true' or '$(APPVEYOR)' != '')">true</EnableCodeCoverage>
       <CodeCoverageCommand Condition="'$(EnableCodeCoverage)' == 'true'">/EnableCodeCoverage </CodeCoverageCommand>
       <CodeCoverageCommand Condition="'$(EnableCodeCoverage)' != 'true'"></CodeCoverageCommand>
       <TestSettings Condition="'$(TestSettings)' == '' and '$(EnableCodeCoverage)' == 'true'">$(SolutionDir)SqlLocalDb.coverage.runsettings</TestSettings>

--- a/src/SqlLocalDb.msbuild
+++ b/src/SqlLocalDb.msbuild
@@ -119,15 +119,22 @@
       <TestFramework Condition="'$(TestFramework)' == ''">Framework40</TestFramework>
       <TestInIsolation Condition="'$(TestInIsolation)' == ''">true</TestInIsolation>
       <SpecifyTestSettingsFile Condition="'$(SpecifyTestSettingsFile)' == ''">true</SpecifyTestSettingsFile>
-      <TestSettings Condition="'$(TestSettings)' == ''">$(SolutionDir)SqlLocalDb.runsettings</TestSettings>
       <TestOptions Condition="'$(TestCaseFilter)' != ''">$(TestOptions) %22$(TestCaseFilter)%22</TestOptions>
       <!--
         If this is an AppVeyor CI build use the custom logger that registers the test results with the build log.
       -->
       <TestOptions Condition="'$(APPVEYOR)' != ''">$(TestOptions) /logger:Appveyor</TestOptions>
-      <EnableCodeCoverage Condition="'$(EnableCodeCoverage)' == ''">true</EnableCodeCoverage>
+      <!--
+        SKUs of Visual Studio 2015 below Enterprise do not have the appropriate code coverage adapter installed.
+      -->
+      <_IsVSEnterprise Condition="'$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\VisualStudio\14.0\Setup\vs\Enterprise@ProductDir)' != ''">true</_IsVSEnterprise>
+      <_IsVSEnterprise Condition="'$(_IsVSEnterprise)' == '' and '$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\14.0\Setup\vs\Enterprise@ProductDir)' != ''">true</_IsVSEnterprise>
+      <_IsVSEnterprise Condition="'$(_IsVSEnterprise)' == ''">false</_IsVSEnterprise>
+      <EnableCodeCoverage Condition="'$(EnableCodeCoverage)' == '' and '$(_IsVSEnterprise)' == 'true'">true</EnableCodeCoverage>
       <CodeCoverageCommand Condition="'$(EnableCodeCoverage)' == 'true'">/EnableCodeCoverage </CodeCoverageCommand>
       <CodeCoverageCommand Condition="'$(EnableCodeCoverage)' != 'true'"></CodeCoverageCommand>
+      <TestSettings Condition="'$(TestSettings)' == '' and '$(EnableCodeCoverage)' == 'true'">$(SolutionDir)SqlLocalDb.coverage.runsettings</TestSettings>
+      <TestSettings Condition="'$(TestSettings)' == '' and '$(EnableCodeCoverage)' != 'true'">$(SolutionDir)SqlLocalDb.runsettings</TestSettings>
     </PropertyGroup>
     <!--
       Find the test assemblies and declare the platforms to test for.

--- a/src/SqlLocalDb.runsettings
+++ b/src/SqlLocalDb.runsettings
@@ -3,34 +3,4 @@
   <RunConfiguration>
     <ResultsDirectory>.\TestResults</ResultsDirectory>
   </RunConfiguration>
-  <DataCollectionRunSettings>
-    <DataCollectors>
-      <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-        <Configuration>
-          <CodeCoverage>
-            <CollectAspDotNet>False</CollectAspDotNet>
-            <CollectFromChildProcesses>False</CollectFromChildProcesses>
-            <ModulePaths>
-              <Exclude>
-                <ModulePath>.*appveyor.*</ModulePath>
-                <ModulePath>.*ATL.*</ModulePath>
-                <ModulePath>.*CPPUnitTestFramework.*</ModulePath>
-                <ModulePath>.*MSVC.*</ModulePath>
-                <ModulePath>.*Tests.*</ModulePath>
-              </Exclude>
-            </ModulePaths>
-            <Attributes>
-              <Exclude>
-                <Attribute>^System.CodeDom.Compiler.GeneratedCodeAttribute$</Attribute>
-                <Attribute>^System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute$</Attribute>
-                <Attribute>^System.Diagnostics.DebuggerHiddenAttribute$</Attribute>
-                <Attribute>^System.Diagnostics.DebuggerNonUserCodeAttribute$</Attribute>
-                <Attribute>^System.Runtime.CompilerServices.CompilerGeneratedAttribute$</Attribute>
-              </Exclude>
-            </Attributes>
-          </CodeCoverage>
-        </Configuration>
-      </DataCollector>
-    </DataCollectors>
-  </DataCollectionRunSettings>
 </RunSettings>

--- a/src/SqlLocalDb.sln
+++ b/src/SqlLocalDb.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Data.SqlLocalDb", "SqlLocalDb\System.Data.SqlLocalDb.csproj", "{B235F2A6-A8A2-4CE6-B3B0-54FFB89DE7DD}"
 EndProject
@@ -22,6 +22,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\LICENSE.txt = ..\LICENSE.txt
 		..\readme.md = ..\readme.md
 		SqlLocalDb.Common.targets = SqlLocalDb.Common.targets
+		SqlLocalDb.Coverage.runsettings = SqlLocalDb.Coverage.runsettings
 		SqlLocalDb.msbuild = SqlLocalDb.msbuild
 		SqlLocalDb.nuspec = SqlLocalDb.nuspec
 		SqlLocalDb.ruleset = SqlLocalDb.ruleset


### PR DESCRIPTION
This PR fixes #19 by only enabling code coverage in ```SqlLocalDb.msbuild``` if Visual Studio 2015 Enterprise is installed or if the build is running in AppVeyor.