### PR TITLE
Support SQL Server LocalDB 2016

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ SQL LocalDB Wrapper is a .NET 3.5 assembly providing interop with the [Microsoft
 
 It is designed to support use of dependency injection by consumers by implementing interfaces, and is also designed to fit with the other data access providers defined under the System.Data namespaces.
 
-The assembly supports using SQL Server LocalDB 2012 and 2014 for both the x86 and x64 platforms.
+The assembly supports using SQL Server LocalDB 2012 and 2014 for both the x86 and x64 platforms and SQL Server LocalDB 2016 for the x64 platform.
 
 ## Downloads
 

--- a/src/SqlLocalDb.UnitTests/ExtensionsTests.cs
+++ b/src/SqlLocalDb.UnitTests/ExtensionsTests.cs
@@ -863,8 +863,9 @@ namespace System.Data.SqlLocalDb
 
         [TestMethod]
         [TestCategory(TestCategories.SqlServer2014)]
-        [Description("Tests GetOrCreateInstance() if instanceName is the SQL LocalDB 2014 default instance name.")]
-        public void Extensions_GetOrCreateInstance_For_2014_Default_Instance_Name()
+        [TestCategory(TestCategories.SqlServer2016)]
+        [Description("Tests GetOrCreateInstance() if instanceName is the SQL LocalDB 2014 and 2016 default instance name.")]
+        public void Extensions_GetOrCreateInstance_For_2014_And_2016_Default_Instance_Name()
         {
             // Arrange
             ISqlLocalDbProvider value = new SqlLocalDbProvider();

--- a/src/SqlLocalDb.UnitTests/SqlLocalDbApiTests.DefaultInstanceName.2016.config
+++ b/src/SqlLocalDb.UnitTests/SqlLocalDbApiTests.DefaultInstanceName.2016.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="SQLLocalDB:OverrideVersion" value="13.0" />
+  </appSettings>
+</configuration>

--- a/src/SqlLocalDb.UnitTests/SqlLocalDbApiTests.cs
+++ b/src/SqlLocalDb.UnitTests/SqlLocalDbApiTests.cs
@@ -1394,6 +1394,7 @@ namespace System.Data.SqlLocalDb
         [TestMethod]
         [TestCategory(TestCategories.SqlServer2012)]
         [TestCategory(TestCategories.SqlServer2014)]
+        [TestCategory(TestCategories.SqlServer2016)]
         [Description("Tests that the DefaultInstanceName property returns the correct value.")]
         public void SqlLocalDbApi_DefaultInstanceName_Returns_Correct_Value()
         {
@@ -1445,6 +1446,25 @@ namespace System.Data.SqlLocalDb
                     Assert.AreEqual("MSSQLLocalDB", result, "SqlLocalDbApi.DefaultInstanceName returned incorrect value.");
                 },
                 configurationFile: "SqlLocalDbApiTests.DefaultInstanceName.2014.config");
+        }
+
+        [Ignore] // Not yet installed in AppVeyor CI
+        [TestMethod]
+        [TestCategory(TestCategories.SqlServer2016)]
+        [Description("Tests that the DefaultInstanceName property returns the correct value for SQL LocalDB 2016.")]
+        public void SqlLocalDbApi_DefaultInstanceName_Returns_Correct_Value_2016()
+        {
+            // Arrange
+            Helpers.InvokeInNewAppDomain(
+                () =>
+                {
+                    // Act
+                    string result = SqlLocalDbApi.DefaultInstanceName;
+
+                    // Assert
+                    Assert.AreEqual("MSSQLLocalDB", result, "SqlLocalDbApi.DefaultInstanceName returned incorrect value.");
+                },
+                configurationFile: "SqlLocalDbApiTests.DefaultInstanceName.2016.config");
         }
 
         [TestMethod]

--- a/src/SqlLocalDb.UnitTests/SqlLocalDbProviderTests.cs
+++ b/src/SqlLocalDb.UnitTests/SqlLocalDbProviderTests.cs
@@ -303,8 +303,9 @@ namespace System.Data.SqlLocalDb
 
         [TestMethod]
         [TestCategory(TestCategories.SqlServer2014)]
-        [Description("Tests CreateInstance(string) uses the specfied version of SQL LocalDB if overridden for SQL Server LocalDB 2014.")]
-        public void SqlLocalDbProvider_CreateInstance_Specifies_No_Version_If_Default_Instance_Name_Specified_2014()
+        [TestCategory(TestCategories.SqlServer2016)]
+        [Description("Tests CreateInstance(string) uses the specfied version of SQL LocalDB if overridden for SQL Server LocalDB 2014 and 2016.")]
+        public void SqlLocalDbProvider_CreateInstance_Specifies_No_Version_If_Default_Instance_Name_Specified_2014_2016()
         {
             // Arrange
             string instanceName = "MSSQLLocalDB";

--- a/src/SqlLocalDb.UnitTests/System.Data.SqlLocalDb.UnitTests.csproj
+++ b/src/SqlLocalDb.UnitTests/System.Data.SqlLocalDb.UnitTests.csproj
@@ -130,6 +130,9 @@
     <None Include="SqlLocalDbApiTests.DefaultInstanceName.2012.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="SqlLocalDbApiTests.DefaultInstanceName.2016.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="SqlLocalDbApiTests.DefaultInstanceName.2014.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Update the readme documentation to list support for SQL Server LocalDB 2016 and update the tests.

Resolves #21.