### PR TITLE
Fix Travis CI badge and links

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
     <Authors>Martin Costello</Authors>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)SqlLocalDb.ruleset</CodeAnalysisRuleSet>
     <Company>https://github.com/martincostello/sqllocaldb</Company>
-    <Copyright>Martin Costello (c) 2015-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
+    <Copyright>Martin Costello (c) 2012-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <GenerateGitMetadata Condition=" '$(CI)' == 'true' and '$(GenerateGitMetadata)' == '' ">true</GenerateGitMetadata>

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 SQL LocalDB Wrapper is a .NET Standard 2.0 library providing interop with the [Microsoft SQL Server LocalDB](https://docs.microsoft.com/en-us/sql/relational-databases/express-localdb-instance-apis/sql-server-express-localdb-reference-instance-apis?view=sql-server-2017 "SQL Server Express LocalDB Reference - Instance APIs") Instance API from managed code using .NET APIs.
 
-[![NuGet](https://buildstats.info/nuget/MartinCostello.SqlLocalDb)](http://www.nuget.org/packages/MartinCostello.SqlLocalDb "Download MartinCostello.SqlLocalDb from NuGet")
+[![NuGet](https://buildstats.info/nuget/MartinCostello.SqlLocalDb?includePreReleases=true)](http://www.nuget.org/packages/MartinCostello.SqlLocalDb "Download MartinCostello.SqlLocalDb from NuGet")
 
 | | Windows | Linux |
 |:-:|:-:|:-:|
@@ -13,7 +13,7 @@ SQL LocalDB Wrapper is a .NET Standard 2.0 library providing interop with the [M
 
 This library exposes types that wrap the native SQL LocalDB Instance API to perform operations on SQL LocalDB such as for managing instances (create, delete, start, stop) and obtaining SQL connection strings for existing instances.
 
-Microsoft SQL Server LocalDB 2012 and later is supported for both x86 and x64 on Microsoft Windows and targets `netstandard2.0`.
+Microsoft SQL Server LocalDB 2012 and later is supported for both x86 and x64 on Microsoft Windows and the library targets `netstandard2.0`.
 
 While the library can be compiled and referenced in .NET Core applications on non-Windows Operating Systems, SQL LocalDB is only supported on Windows. Non-Windows Operating Systems can query to determine that the SQL LocalDB Instance API is not installed, but other usage will cause a `PlatformNotSupportedException` to be thrown.
 
@@ -59,7 +59,7 @@ This project is licensed under the [Apache 2.0](http://www.apache.org/licenses/L
 
 ## Building and Testing
 
-Compiling the library yourself requires Git and the [.NET Core SDK](https://www.microsoft.com/net/download/core "Download the .NET Core SDK") to be installed (version 2.1.302 or later).
+Compiling the library yourself requires Git and the [.NET Core SDK](https://www.microsoft.com/net/download/core "Download the .NET Core SDK") to be installed (version `2.1.302` or later).
 
 For all of the tests to be functional you must also have at least one version of SQL LocalDB installed.
 

--- a/readme.md
+++ b/readme.md
@@ -6,8 +6,8 @@ SQL LocalDB Wrapper is a .NET Standard 2.0 library providing interop with the [M
 
 | | Windows | Linux |
 |:-:|:-:|:-:|
-| **Build Status** | [![Windows build status](https://img.shields.io/appveyor/ci/martincostello/sqllocaldb/master.svg)](https://ci.appveyor.com/project/martincostello/sqllocaldb) [![Code coverage](https://codecov.io/gh/martincostello/sqllocaldb/branch/master/graph/badge.svg)](https://codecov.io/gh/martincostello/sqllocaldb) | [![Linux build status](https://img.shields.io/travis/martincostello/sqllocaldb/master.svg)](https://travis-ci.org/martincostello/sqllocaldb) |
-| **Build History** | [![Windows build history](https://buildstats.info/appveyor/chart/martincostello/sqllocaldb?branch=master&includeBuildsFromPullRequest=false)](https://ci.appveyor.com/project/martincostello/sqllocaldb) | [![Linux build history](https://buildstats.info/travisci/chart/martincostello/sqllocaldb?branch=master&includeBuildsFromPullRequest=false)](https://travis-ci.org/martincostello/sqllocaldb) |
+| **Build Status** | [![Windows build status](https://img.shields.io/appveyor/ci/martincostello/sqllocaldb/master.svg)](https://ci.appveyor.com/project/martincostello/sqllocaldb) [![Code coverage](https://codecov.io/gh/martincostello/sqllocaldb/branch/master/graph/badge.svg)](https://codecov.io/gh/martincostello/sqllocaldb) | [![Linux build status](https://img.shields.io/travis-ci/com/martincostello/sqllocaldb/master.svg)](https://travis-ci.com/martincostello/sqllocaldb) |
+| **Build History** | [![Windows build history](https://buildstats.info/appveyor/chart/martincostello/sqllocaldb?branch=master&includeBuildsFromPullRequest=false)](https://ci.appveyor.com/project/martincostello/sqllocaldb) | [![Linux build history](https://buildstats.info/travisci/chart/martincostello/sqllocaldb?branch=master&includeBuildsFromPullRequest=false)](https://travis-ci.com/martincostello/sqllocaldb) |
 
 ## Introduction
 


### PR DESCRIPTION
Fix badge and links to Travis CI as they were using `.org` instead of `.com`.

The chart doesn't work yet, have logged an issue: dustinmoris/CI-BuildStats#17.
