### PR TITLE
Add ConnectionString to TemporarySqlLocalDbInstance

### DIFF
--- a/samples/TodoApp.Tests/TodoRepositoryTests.cs
+++ b/samples/TodoApp.Tests/TodoRepositoryTests.cs
@@ -35,9 +35,8 @@ namespace TodoApp.Tests
             {
                 using (TemporarySqlLocalDbInstance instance = localDB.CreateTemporaryInstance(deleteFiles: true))
                 {
-                    string connectionString = instance.GetInstanceInfo().GetConnectionString();
-
-                    var builder = new DbContextOptionsBuilder<TodoContext>().UseSqlServer(connectionString);
+                    var builder = new DbContextOptionsBuilder<TodoContext>()
+                        .UseSqlServer(instance.ConnectionString);
 
                     using (var context = new TodoContext(builder.Options))
                     {

--- a/src/SqlLocalDb/TemporarySqlLocalDbInstance.cs
+++ b/src/SqlLocalDb/TemporarySqlLocalDbInstance.cs
@@ -51,6 +51,14 @@ namespace MartinCostello.SqlLocalDb
         ~TemporarySqlLocalDbInstance() => DisposeInternal();
 
         /// <summary>
+        /// Gets the connection string for the temporary SQL LocalDB instance.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">
+        /// Thrown if the instance has been disposed of.
+        /// </exception>
+        public string ConnectionString => GetInstanceInfo().GetConnectionString();
+
+        /// <summary>
         /// Gets the name of the temporary SQL LocalDB instance.
         /// </summary>
         /// <exception cref="ObjectDisposedException">

--- a/tests/SqlLocalDb.Tests/SqlLocalDbApiTests.cs
+++ b/tests/SqlLocalDb.Tests/SqlLocalDbApiTests.cs
@@ -386,7 +386,18 @@ namespace MartinCostello.SqlLocalDb
                 // Assert
                 deleted.ShouldBeGreaterThanOrEqualTo(1);
                 IReadOnlyList<string> namesAfter = actual.GetInstanceNames();
-                namesAfter.ShouldBeSubsetOf(namesBefore);
+
+                int instancesDeleted = 0;
+
+                foreach (string name in namesBefore)
+                {
+                    if (!namesAfter.Contains(name))
+                    {
+                        instancesDeleted++;
+                    }
+                }
+
+                instancesDeleted.ShouldBeGreaterThanOrEqualTo(1);
             }
         }
 


### PR DESCRIPTION
Add a convenience property to `TemporarySqlLocalDbInstance` that returns the connection string to the LocalDB instance.
