### PR TITLE
Usability improvements

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,10 +25,30 @@ To install the library from [NuGet](https://www.nuget.org/packages/MartinCostell
 dotnet add package MartinCostello.SqlLocalDb
 ```
 
-### Basic Examples
+### Basic Example
 
-```cs
-// TODO
+```csharp
+// using MartinCostello.SqlLocalDb;
+
+using (var localDB = new SqlLocalDbApi())
+{
+    ISqlLocalDbInstanceInfo instance = localDB.GetOrCreateInstance("MyInstance");
+    ISqlLocalDbInstanceManager manager = instance.Manage();
+
+    if (!instance.IsRunning)
+    {
+        manager.Start();
+    }
+
+    using (SqlConnection connection = instance.CreateConnection())
+    {
+        connection.Open();
+
+        // Use the SQL connection...
+    }
+
+    manager.Stop();
+}
 ```
 
 ### Further Examples

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,7 @@ Further examples of using the library can be found by following the links below:
 
   1. The [wiki](https://github.com/martincostello/sqllocaldb/wiki/Examples "Examples in the SQL LocalDB Wrapper wiki").
   1. The [sample application](https://github.com/martincostello/sqllocaldb/tree/master/samples "TodoApp sample").
+  1. The [examples written as tests](https://github.com/martincostello/sqllocaldb/blob/master/tests/SqlLocalDb.Tests/Examples.cs "Examples as tests").
   1. The library's [own tests](https://github.com/martincostello/sqllocaldb/tree/master/tests/SqlLocalDb.Tests "View MartinCostello.SqlLocalDb's tests").
 
 ## Migrating from System.Data.SqlLocalDb

--- a/src/SqlLocalDb/SqlLocalDbApi.cs
+++ b/src/SqlLocalDb/SqlLocalDbApi.cs
@@ -70,7 +70,7 @@ namespace MartinCostello.SqlLocalDb
         /// Initializes a new instance of the <see cref="SqlLocalDbApi"/> class.
         /// </summary>
         public SqlLocalDbApi()
-            : this(new SqlLocalDbOptions(), new NullLoggerFactory())
+            : this(new SqlLocalDbOptions(), NullLoggerFactory.Instance)
         {
         }
 

--- a/src/SqlLocalDb/SqlLocalDbApi.cs
+++ b/src/SqlLocalDb/SqlLocalDbApi.cs
@@ -12,6 +12,7 @@ using System.Security.Principal;
 using System.Text;
 using MartinCostello.SqlLocalDb.Interop;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace MartinCostello.SqlLocalDb
 {
@@ -64,6 +65,14 @@ namespace MartinCostello.SqlLocalDb
         /// The timeout for stopping an instance of LocalDB.
         /// </summary>
         private TimeSpan _stopTimeout;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqlLocalDbApi"/> class.
+        /// </summary>
+        public SqlLocalDbApi()
+            : this(new SqlLocalDbOptions(), new NullLoggerFactory())
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SqlLocalDbApi"/> class.

--- a/src/SqlLocalDb/SqlLocalDbOptions.cs
+++ b/src/SqlLocalDb/SqlLocalDbOptions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Martin Costello, 2012-2018. All rights reserved.
+﻿// Copyright (c) Martin Costello, 2012-2018. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System;
@@ -22,6 +22,9 @@ namespace MartinCostello.SqlLocalDb
         /// Gets or sets a value indicating whether to automatically delete the
         /// files associated with SQL LocalDB instances when they are deleted.
         /// </summary>
+        /// <remarks>
+        /// The default value is <see langword="false"/>.
+        /// </remarks>
         public bool AutomaticallyDeleteInstanceFiles { get; set; }
 
         /// <summary>
@@ -37,11 +40,17 @@ namespace MartinCostello.SqlLocalDb
         /// <summary>
         /// Gets or sets the options to use when stopping instances of SQL LocalDB.
         /// </summary>
+        /// <remarks>
+        /// The default value is <see cref="StopInstanceOptions.None"/>.
+        /// </remarks>
         public StopInstanceOptions StopOptions { get; set; } = StopInstanceOptions.None;
 
         /// <summary>
         /// Gets or sets the default timeout to use when stopping instances of SQL LocalDB.
         /// </summary>
+        /// <remarks>
+        /// The default value is 1 minute.
+        /// </remarks>
         public TimeSpan StopTimeout { get; set; } = TimeSpan.FromMinutes(1);
 
         /// <summary>

--- a/tests/SqlLocalDb.Tests/Examples.cs
+++ b/tests/SqlLocalDb.Tests/Examples.cs
@@ -13,7 +13,7 @@ namespace MartinCostello.SqlLocalDb
     /// </summary>
     public static class Examples
     {
-        [Fact]
+        [WindowsOnlyFact]
         public static void Create_A_Sql_LocalDB_Instance()
         {
             using (var localDB = new SqlLocalDbApi())
@@ -37,7 +37,7 @@ namespace MartinCostello.SqlLocalDb
             }
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public static void Create_A_Temporary_Sql_LocalDB_Instance()
         {
             using (var localDB = new SqlLocalDbApi())
@@ -54,7 +54,7 @@ namespace MartinCostello.SqlLocalDb
             }
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public static void Use_With_Dependency_Injection()
         {
             // Register with SQL LocalDB services

--- a/tests/SqlLocalDb.Tests/Examples.cs
+++ b/tests/SqlLocalDb.Tests/Examples.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Martin Costello, 2012-2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Data.SqlClient;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MartinCostello.SqlLocalDb
+{
+    /// <summary>
+    /// A class that contains examples for using <c>MartinCostello.SqlLocalDb</c>.
+    /// </summary>
+    public static class Examples
+    {
+        [Fact]
+        public static void Create_A_Sql_LocalDB_Instance()
+        {
+            using (var localDB = new SqlLocalDbApi())
+            {
+                ISqlLocalDbInstanceInfo instance = localDB.GetOrCreateInstance("MyInstance");
+                ISqlLocalDbInstanceManager manager = instance.Manage();
+
+                if (!instance.IsRunning)
+                {
+                    manager.Start();
+                }
+
+                using (SqlConnection connection = instance.CreateConnection())
+                {
+                    connection.Open();
+
+                    // Use the SQL connection...
+                }
+
+                manager.Stop();
+            }
+        }
+
+        [Fact]
+        public static void Create_A_Temporary_Sql_LocalDB_Instance()
+        {
+            using (var localDB = new SqlLocalDbApi())
+            {
+                using (TemporarySqlLocalDbInstance instance = localDB.CreateTemporaryInstance(deleteFiles: true))
+                {
+                    using (var connection = new SqlConnection(instance.ConnectionString))
+                    {
+                        connection.Open();
+
+                        // Use the SQL connection...
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public static void Use_With_Dependency_Injection()
+        {
+            // Register with SQL LocalDB services
+            var services = new ServiceCollection()
+                .AddLogging()
+                .AddSqlLocalDB();
+
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            using (IServiceScope scope = serviceProvider.CreateScope())
+            {
+                ISqlLocalDbApi localDB = scope.ServiceProvider.GetService<ISqlLocalDbApi>();
+                ISqlLocalDbInstanceInfo instance = localDB.GetDefaultInstance();
+                ISqlLocalDbInstanceManager manager = instance.Manage();
+
+                if (!instance.IsRunning)
+                {
+                    manager.Start();
+                }
+
+                using (SqlConnection connection = instance.CreateConnection())
+                {
+                    connection.Open();
+
+                    // Use the SQL connection...
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
  1. Add `<remarks>` with default values to `SqlLocalDbOptions`.
  1. Add default constructor to `SqlLocalDbApi`.
  1. Add examples to `README` and via a test class.

Relates to #41.