### PR TITLE
Simplify dependencies

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -47,9 +47,12 @@ else {
 
 if ($installDotNetSdk -eq $true) {
     $env:DOTNET_INSTALL_DIR = Join-Path "$(Convert-Path "$PSScriptRoot")" ".dotnetcli"
+    $sdkPath = Join-Path $env:DOTNET_INSTALL_DIR "sdk\$dotnetVersion"
 
-    if (!(Test-Path $env:DOTNET_INSTALL_DIR)) {
-        mkdir $env:DOTNET_INSTALL_DIR | Out-Null
+    if (!(Test-Path $sdkPath)) {
+        if (!(Test-Path $env:DOTNET_INSTALL_DIR)) {
+            mkdir $env:DOTNET_INSTALL_DIR | Out-Null
+        }
         $installScript = Join-Path $env:DOTNET_INSTALL_DIR "install.ps1"
         Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/v$dotnetVersion/scripts/obtain/dotnet-install.ps1" -OutFile $installScript -UseBasicParsing
         & $installScript -Version "$dotnetVersion" -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.6.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63102-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
     <PackageReference Include="OpenCover" Version="4.6.519" PrivateAssets="All" />
     <PackageReference Include="ReportGenerator" Version="3.1.2" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />

--- a/src/SqlLocalDb/MartinCostello.SqlLocalDb.csproj
+++ b/src/SqlLocalDb/MartinCostello.SqlLocalDb.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>SQL LocalDB Wrapper</AssemblyTitle>
     <DebugType>full</DebugType>
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/tests/SqlLocalDb.Tests/NotInParallelTests.cs
+++ b/tests/SqlLocalDb.Tests/NotInParallelTests.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Martin Costello, 2012-2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MartinCostello.SqlLocalDb
+{
+    /// <summary>
+    /// A class containing tests that perform global operations that may cause other tests to fail if run in parallel.
+    /// </summary>
+    [CollectionDefinition("NotInParallel", DisableParallelization = true)]
+    public class NotInParallelTests
+    {
+        private readonly ILoggerFactory _loggerFactory;
+
+        public NotInParallelTests(ITestOutputHelper outputHelper)
+        {
+            _loggerFactory = outputHelper.AsLoggerFactory();
+        }
+
+        [WindowsCIOnlyFact]
+        public void Can_Delete_User_Instances()
+        {
+            // Arrange
+            using (var actual = new SqlLocalDbApi(_loggerFactory))
+            {
+                actual.CreateInstance(Guid.NewGuid().ToString());
+
+                IReadOnlyList<string> namesBefore = actual.GetInstanceNames();
+
+                // Act
+                int deleted = actual.DeleteUserInstances(deleteFiles: true);
+
+                // Assert
+                deleted.ShouldBeGreaterThanOrEqualTo(1);
+                IReadOnlyList<string> namesAfter = actual.GetInstanceNames();
+
+                int instancesDeleted = 0;
+
+                foreach (string name in namesBefore)
+                {
+                    if (!namesAfter.Contains(name))
+                    {
+                        instancesDeleted++;
+                    }
+                }
+
+                instancesDeleted.ShouldBeGreaterThanOrEqualTo(1);
+            }
+        }
+    }
+}

--- a/tests/SqlLocalDb.Tests/SqlLocalDbApiTests.cs
+++ b/tests/SqlLocalDb.Tests/SqlLocalDbApiTests.cs
@@ -370,37 +370,6 @@ namespace MartinCostello.SqlLocalDb
             }
         }
 
-        [WindowsCIOnlyFact]
-        public void Can_Delete_User_Instances()
-        {
-            // Arrange
-            using (var actual = new SqlLocalDbApi(_loggerFactory))
-            {
-                actual.CreateInstance(Guid.NewGuid().ToString());
-
-                IReadOnlyList<string> namesBefore = actual.GetInstanceNames();
-
-                // Act
-                int deleted = actual.DeleteUserInstances(deleteFiles: true);
-
-                // Assert
-                deleted.ShouldBeGreaterThanOrEqualTo(1);
-                IReadOnlyList<string> namesAfter = actual.GetInstanceNames();
-
-                int instancesDeleted = 0;
-
-                foreach (string name in namesBefore)
-                {
-                    if (!namesAfter.Contains(name))
-                    {
-                        instancesDeleted++;
-                    }
-                }
-
-                instancesDeleted.ShouldBeGreaterThanOrEqualTo(1);
-            }
-        }
-
         [Fact]
         public void SqlLocalDbApi_Is_ISqlLocalDbApiAdapter()
         {


### PR DESCRIPTION
  * Use `Microsoft.Win32.Registry` instead of `Microsoft.Windows.Compatibility` to simplify the dependency graph.
  * Update `Microsoft.SourceLink.GitHub` to the latest beta.
  * Fix updating the .NET Core SDK when a different version is already installed in the repo directory, as it would think it was installed and then fail because it didn't actually install it.