### PR TITLE
Sync versions of xunit-logging

### DIFF
--- a/tests/SqlLocalDb.Tests/MartinCostello.SqlLocalDb.Tests.csproj
+++ b/tests/SqlLocalDb.Tests/MartinCostello.SqlLocalDb.Tests.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="..\..\src\SqlLocalDb\MartinCostello.SqlLocalDb.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.0-alpha3" />
+    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.0-alpha4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />


### PR DESCRIPTION
Use `0.1.0-alpha4` of `MartinCostello.Logging.XUnit` in both test projects.
