### PR TITLE
Fail Azure Pipelines CI if test(s) fail

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -153,6 +153,8 @@ function DotNetTest {
                 `"-filter:+[MartinCostello.SqlLocalDb]* -[MartinCostello.SqlLocalDb.Tests]*`"
         }
 
+        $dotNetTestExitCode = $LASTEXITCODE
+
         & $dotnet `
             $reportGeneratorPath `
             `"-reports:$coverageOutput`" `
@@ -161,8 +163,8 @@ function DotNetTest {
             -verbosity:Warning
     }
 
-    if ($LASTEXITCODE -ne 0) {
-        throw "dotnet test failed with exit code $LASTEXITCODE"
+    if ($dotNetTestExitCode -ne 0) {
+        throw "dotnet test failed with exit code $dotNetTestExitCode"
     }
 }
 


### PR DESCRIPTION
Fix code coverage report generation overwriting the exit code from `dotnet test`.

Resolves #60.
