### PR TITLE
Update leftover reference

### DIFF
--- a/samples/TodoApp.Tests/TodoApp.Tests.csproj
+++ b/samples/TodoApp.Tests/TodoApp.Tests.csproj
@@ -7,7 +7,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.0-alpha4" />
+    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="NodaTime.Testing" Version="2.4.0" />
     <PackageReference Include="xunit" Version="2.4.0" />


### PR DESCRIPTION
Update a leftover reference to a pre-release version of `MartinCostello.Logging.XUnit` missed from #68.
