### PR TITLE
Remove extra space

### DIFF
--- a/src/SqlLocalDb/ILoggerExtensions.cs
+++ b/src/SqlLocalDb/ILoggerExtensions.cs
@@ -303,7 +303,7 @@ namespace MartinCostello.SqlLocalDb
         /// <summary>
         /// Logging delegate for when SQL LocalDB tracing is starting.
         /// </summary>
-        private static readonly Action<ILogger,  Exception> _startingTracing = LoggerMessage.Define(
+        private static readonly Action<ILogger, Exception> _startingTracing = LoggerMessage.Define(
             LogLevel.Debug,
             EventIds.StartingTracing,
             SR.ILoggerExtensions_StartTracing);


### PR DESCRIPTION
Fix one case of an extra space from `dotnet format`.
