### PR TITLE
Update GitHub Actions SDK version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ macos-latest, ubuntu-latest, windows-latest ]
         include:
@@ -31,7 +32,7 @@ jobs:
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.202
+        dotnet-version: 3.1.300
 
     - name: Build, Test and Package
       shell: pwsh


### PR DESCRIPTION
  * Update the version of the .NET Core SDK used for GitHub Actions to match `global.json`.
  * Disable fail-fast.
