### PR TITLE
Remove net5.0 TFM

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,6 @@ cd sqllocaldb
 
 ## Copyright and Trademarks
 
-This library is copyright (©) Martin Costello 2012-2020.
+This library is copyright (©) Martin Costello 2012-2021.
 
 [Microsoft SQL Server](https://www.microsoft.com/en-gb/sql-server/) is a trademark and copyright of the Microsoft Corporation.

--- a/src/SqlLocalDb/MartinCostello.SqlLocalDb.csproj
+++ b/src/SqlLocalDb/MartinCostello.SqlLocalDb.csproj
@@ -8,7 +8,7 @@
     <PackageId>MartinCostello.SqlLocalDb</PackageId>
     <RootNamespace>MartinCostello.SqlLocalDb</RootNamespace>
     <Summary>$(Description)</Summary>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Title>SQL LocalDB Wrapper</Title>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Remove the .NET 5 TFM for a patch release. Will support .NET 6 later this year instead.
