### PR TITLE
Use NativeLibrary class

### DIFF
--- a/src/SqlLocalDb/Interop/NativeMethods.cs
+++ b/src/SqlLocalDb/Interop/NativeMethods.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Martin Costello, 2012-2018. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+#if !NET6_0_OR_GREATER
+
 using System.Runtime.InteropServices;
 
 namespace MartinCostello.SqlLocalDb.Interop;
@@ -27,12 +29,12 @@ internal static class NativeMethods
     /// <summary>
     /// Frees a specified library.
     /// </summary>
-    /// <param name="handle">The handle to the module to free.</param>
+    /// <param name="hModule">The handle to the module to free.</param>
     /// <returns>Whether the library was successfully unloaded.</returns>
     [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories)]
     [DllImport(KernelLibName)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    internal static extern bool FreeLibrary(IntPtr handle);
+    internal static extern bool FreeLibrary(IntPtr hModule);
 
     /// <summary>
     /// Retrieves the address of an exported function or variable from the specified dynamic-link library (DLL).
@@ -77,3 +79,4 @@ internal static class NativeMethods
         int dwFlags);
 #pragma warning restore CA2101
 }
+#endif

--- a/src/SqlLocalDb/Interop/SafeLibraryHandle.cs
+++ b/src/SqlLocalDb/Interop/SafeLibraryHandle.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2012-2018. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 
 namespace MartinCostello.SqlLocalDb.Interop;
@@ -10,6 +11,17 @@ namespace MartinCostello.SqlLocalDb.Interop;
 /// </summary>
 internal sealed class SafeLibraryHandle : SafeHandleZeroOrMinusOneIsInvalid
 {
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SafeLibraryHandle"/> class.
+    /// </summary>
+    /// <param name="handle">The pre-existing handle to use.</param>
+    public SafeLibraryHandle(IntPtr handle)
+        : base(true)
+    {
+        SetHandle(handle);
+    }
+#else
     /// <summary>
     /// Initializes a new instance of the <see cref="SafeLibraryHandle"/> class.
     /// </summary>
@@ -17,6 +29,7 @@ internal sealed class SafeLibraryHandle : SafeHandleZeroOrMinusOneIsInvalid
         : base(true)
     {
     }
+#endif
 
     /// <summary>
     /// Executes the code required to free the handle.
@@ -27,5 +40,13 @@ internal sealed class SafeLibraryHandle : SafeHandleZeroOrMinusOneIsInvalid
     /// <see langword="false"/>. In this case, it generates a ReleaseHandleFailed
     /// Managed Debugging Assistant.
     /// </returns>
-    protected override bool ReleaseHandle() => NativeMethods.FreeLibrary(handle);
+    protected override bool ReleaseHandle()
+#if NET6_0_OR_GREATER
+    {
+        NativeLibrary.Free(handle);
+        return true;
+    }
+#else
+        => NativeMethods.FreeLibrary(handle);
+#endif
 }


### PR DESCRIPTION
Use the `NativeLibrary` class from .NET 6 to remove the need for P/Invoke when targeting `net6.0`.
