### PR TITLE
Fix-up workflow

### DIFF
--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -54,7 +54,7 @@ jobs:
         $tempPath = [System.IO.Path]::GetTempPath()
         $updatesPath = (Join-Path $tempPath "dotnet-outdated.json")
         
-        Write-Host "Checking for .NET NuGet package(s) to update..." -ForegroundColor Yellow
+        Write-Host "Checking for .NET NuGet package(s) to update..."
 
         dotnet outdated `
           --upgrade `
@@ -78,7 +78,7 @@ jobs:
         }
 
         if ($dependencies.Count -gt 0) {
-          Write-Host "Found $($dependencies.Count) .NET NuGet package(s) to update." -ForegroundColor Yellow
+          Write-Host "Found $($dependencies.Count) .NET NuGet package(s) to update." -ForegroundColor Green
 
           $commitMessageLines = @(
             "Update .NET NuGet packages",

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -61,17 +61,21 @@ jobs:
           --version-lock Major `
           --output $updatesPath `
           --include "Microsoft.AspNetCore." `
-          --include "Microsoft.Extensions." `
+          --include "Microsoft.EntityFrameworkCore." `
           --include "Microsoft.NET.Test.Sdk" `
           --include "System."
 
-        $dependencies = `
-          Get-Content -Path $updatesPath | `
-          ConvertFrom-Json | `
-          Select-Object -ExpandProperty projects | `
-          Select-Object -ExpandProperty TargetFrameworks | `
-          Select-Object -ExpandProperty Dependencies | `
-          Sort-Object -Property Name -Unique
+        $dependencies = @()
+
+        if (Test-Path $updatesPath) {
+          $dependencies = `
+            Get-Content -Path $updatesPath | `
+            ConvertFrom-Json | `
+            Select-Object -ExpandProperty projects | `
+            Select-Object -ExpandProperty TargetFrameworks | `
+            Select-Object -ExpandProperty Dependencies | `
+            Sort-Object -Property Name -Unique
+        }
 
         if ($dependencies.Count -gt 0) {
           Write-Host "Found $($dependencies.Count) .NET NuGet package(s) to update." -ForegroundColor Yellow


### PR DESCRIPTION
- Ignore `Microsoft.Extensions` updates.
- Add `Microsoft.EntityFrameworkCore` updates.
- Fix error if there are no packages to update.
