### PR TITLE
Use net7.0 for ReportGenerator

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -116,7 +116,7 @@ function DotNetTest {
     $nugetPath = (Join-Path $packagesRoot ".nuget" "packages")
     $propsFile = (Join-Path $solutionPath "Directory.Packages.props")
     $reportGeneratorVersion = (Select-Xml -Path $propsFile -XPath "//PackageVersion[@Include='ReportGenerator']/@Version").Node.'#text'
-    $reportGeneratorPath = (Join-Path $nugetPath "reportgenerator" $reportGeneratorVersion "tools" "net6.0" "ReportGenerator.dll")
+    $reportGeneratorPath = (Join-Path $nugetPath "reportgenerator" $reportGeneratorVersion "tools" "net7.0" "ReportGenerator.dll")
 
     $coverageOutput = (Join-Path $OutputPath "coverage.*.cobertura.xml")
     $reportOutput = (Join-Path $OutputPath "coverage")


### PR DESCRIPTION
Run ReportGenerator using the `net7.0` TFM.
