### PR TITLE
Remove redundant suppressions

### DIFF
--- a/samples/TodoApp/Program.cs
+++ b/samples/TodoApp/Program.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2012-2018. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-#pragma warning disable CA1812
-#pragma warning disable CA1852
-
 using MartinCostello.SqlLocalDb;
 using Microsoft.EntityFrameworkCore;
 using NodaTime;

--- a/src/TestApp/Program.cs
+++ b/src/TestApp/Program.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2012-2018. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-#pragma warning disable CA1812
-#pragma warning disable CA1852
-
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Principal;


### PR DESCRIPTION
Remove now-redundant suppressions for false-positive code analysis warnings.
