### PR TITLE
Fix public API analyzers

### DIFF
--- a/samples/TodoApp.Tests/TodoApp.Tests.csproj
+++ b/samples/TodoApp.Tests/TodoApp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);CA1303;CA1707;CA2007;RS0016;RS0037;SA1600</NoWarn>
+    <NoWarn>$(NoWarn);CA1303;CA1707;CA2007;SA1600</NoWarn>
     <RootNamespace>TodoApp</RootNamespace>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>

--- a/samples/TodoApp/TodoApp.csproj
+++ b/samples/TodoApp/TodoApp.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AspNetCoreHostingModel>inprocess</AspNetCoreHostingModel>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);CA1062;CA1303;CA1822;CA2007;CA2227;RS0016;RS0037;SA1516;SA1600</NoWarn>
+    <NoWarn>$(NoWarn);CA1062;CA1303;CA1822;CA2007;CA2227;SA1516;SA1600</NoWarn>
     <RootNamespace>TodoApp</RootNamespace>
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>

--- a/src/SqlLocalDb/MartinCostello.SqlLocalDb.csproj
+++ b/src/SqlLocalDb/MartinCostello.SqlLocalDb.csproj
@@ -51,7 +51,7 @@
     <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" VersionOverride="8.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
     <AdditionalFiles Include="PublicAPI\$(TargetFramework)\PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI\$(TargetFramework)\PublicAPI.Unshipped.txt" />
   </ItemGroup>

--- a/src/TestApp/MartinCostello.SqlLocalDb.TestApp.csproj
+++ b/src/TestApp/MartinCostello.SqlLocalDb.TestApp.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Test application for MartinCostello.SqlLocalDb.</Description>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);CA1031;CA2007;RS0016;RS0037;SA1600</NoWarn>
+    <NoWarn>$(NoWarn);CA1031;CA2007;SA1600</NoWarn>
     <OutputType>Exe</OutputType>
     <RootNamespace>MartinCostello.SqlLocalDb</RootNamespace>
     <TargetFramework>net8.0</TargetFramework>

--- a/tests/SqlLocalDb.Tests/MartinCostello.SqlLocalDb.Tests.csproj
+++ b/tests/SqlLocalDb.Tests/MartinCostello.SqlLocalDb.Tests.csproj
@@ -3,7 +3,7 @@
     <Description>Tests for MartinCostello.SqlLocalDb.</Description>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <NoWarn>$(NoWarn);CA1062;CA1707;CA2007;CA2234;CA1303;RS0016;RS0037;SA1600</NoWarn>
+    <NoWarn>$(NoWarn);CA1062;CA1707;CA2007;CA2234;CA1303;SA1600</NoWarn>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <RootNamespace>MartinCostello.SqlLocalDb</RootNamespace>
     <Summary>$(Description)</Summary>


### PR DESCRIPTION
Add `PrivateAssets="All"` so that the dependency isn't transferred to the consuming projects.
