### PR TITLE
Update obsolete usage

### DIFF
--- a/src/SqlLocalDb/SqlLocalDbException.cs
+++ b/src/SqlLocalDb/SqlLocalDbException.cs
@@ -141,7 +141,7 @@ public class SqlLocalDbException : DbException
     /// The <paramref name="info"/> parameter is <see langword="null"/>.
     /// </exception>
 #pragma warning disable IDE0055
-#if NET8_0
+#if NET8_0_OR_GREATER
     [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
 #endif
 #pragma warning restore IDE0055


### PR DESCRIPTION
Mark `GetObjectData()` as obsolete for .NET 8+.
