### PR TITLE
Move suppressions to ruleset

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,6 @@
     <LangVersion>latest</LangVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <NoWarn>$(NoWarn);CA1054;CA1848;CA2234</NoWarn>
     <Nullable>enable</Nullable>
     <PackageIcon></PackageIcon>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/SqlLocalDb.ruleset
+++ b/SqlLocalDb.ruleset
@@ -1,6 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="SqlLocalDb Rules" Description="This rule set contains rules for the SqlLocalDb solution." ToolsVersion="17.0">
   <IncludeAll Action="Warning" />
+  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1054" Action="None" />
+    <Rule Id="CA1515" Action="None" />
+    <Rule Id="CA1848" Action="None" />
+    <Rule Id="CA2234" Action="None" />
+  </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="AD0001" Action="None" />
     <Rule Id="SA1100" Action="None" />


### PR DESCRIPTION
Disable analyser rules in the `.ruleset` file rather than with `NoWarn`.
