### PR TITLE
Upgrade Microsoft.Data.SqlClient

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,12 +1,20 @@
-# Contributing Guide
+# Contributing
 
-To contribute changes (source code, scripts, configuration) to this repository please follow the steps below. These steps are a guideline for contributing and do not necessarily need to be followed for all changes.
+To contribute changes (source code, scripts, configuration) to this repository please follow the steps below.
+These steps are a guideline for contributing and do not necessarily need to be followed for all changes.
 
- 1. If you intend to fix a bug please create an issue before forking the repository.
- 1. Fork the `main` branch of this repository from the latest commit.
- 1. Create a branch from your fork's `main` branch to help isolate your changes from any further work on `main`. If fixing an issue try to reference its name in your branch name (e.g. `issue-123`) to make changes easier to track the changes.
- 1. Work on your proposed changes on your fork. If you are fixing an issue include at least one unit test that reproduces it if the code changes to fix it have not been applied; if you are adding new functionality please include unit tests appropriate to the changes you are making. The [code coverage figure](https://codecov.io/gh/martincostello/sqllocaldb) should be maintained where possible.
- 1. When you think your changes are complete, test that the code builds cleanly using `build.ps1`. There should be no compiler warnings and all tests should pass.
- 1. Once your changes build cleanly locally submit a Pull Request back to the `main` branch from your fork's branch. Ideally commits to your branch should be squashed before creating the Pull Request. If the Pull Request fixes an issue please reference it in the title and/or description. Please keep changes focused around a specific topic rather than include multiple types of changes in a single Pull Request.
- 1. After your Pull Request is created it will build against the repository's continuous integrations.
- 1. Once the Pull Request has been reviewed by the project's [contributors](https://github.com/martincostello/sqllocaldb/graphs/contributors) and the status checks pass your Pull Request will be merged back to the `main` branch, assuming that the changes are deemed appropriate.
+1. If you intend to fix a bug please create an issue before forking the repository.
+1. Fork the `main` branch of this repository from the latest commit.
+1. Create a branch from your fork's `main` branch to help isolate your changes from any further work on `main`.
+   If fixing an issue try to reference its name in your branch name (e.g. `issue-123`) to make changes easier to track the changes.
+1. Work on your proposed changes on your fork. If you are fixing an issue include at least one unit test that reproduces it if the
+   code changes to fix it have not been applied; if you are adding new functionality please include unit tests appropriate to the changes you are making.
+1. When you think your changes are complete, test that the code builds cleanly using `build.ps1`. There should be no compiler warnings and all tests should pass.
+1. Once your changes build cleanly locally submit a Pull Request back to the `main` branch from your fork's branch.
+   Ideally commits to your branch should be squashed before creating the Pull Request. If the Pull Request fixes an issue please reference
+   it in the title and/or description. Please keep changes focused around a specific topic rather than include multiple types of changes in a single Pull Request.
+1. After your Pull Request is created it will build against the repository's continuous integrations.
+1. Once the Pull Request has been reviewed by the project's [contributors][contributors] and the status checks pass your Pull Request
+   will be merged back to the `main` branch, assuming that the changes are deemed appropriate.
+
+[contributors]: https://github.com/martincostello/sqllocaldb/graphs/contributors

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,13 +1,15 @@
-# Issue
+---
+title: '[bug] :'
+---
 
-## Expected behaviour
+### Expected behaviour
 
 <!-- Explain what you expected to happen. -->
 
-## Actual behaviour
+### Actual behaviour
 
 <!-- Explain what actually happened. If an exception occurred, please include a stack trace if available. -->
 
-## Steps to reproduce
+### Steps to reproduce
 
 <!-- A concise, repeatable, example of how to illustrate the issue. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,42 +1,51 @@
 ---
 name: Bug report
 about: Create a bug report to help us improve the library
-title: ''
+title: '[bug] '
 labels: bug
-assignees: ''
 ---
 
+### Describe the bug
+
 <!--
-  This is a template. Feel free to delete any sections that are not relevant.
- -->
+A clear and concise description of what the bug is.
+-->
 
-## Describe the bug
+### Steps To reproduce
 
-<!-- A clear and concise description of what the bug is. -->
+<!--
+A concise, repeatable, example of how to reproduce the issue.
+-->
 
-## Steps To reproduce
+### Expected behaviour
 
-<!-- A concise, repeatable, example of how to reproduce the issue. -->
+<!--
+A clear and concise description of what you expected to happen.
+-->
 
-## Expected behaviour
+### Actual behaviour
 
-<!-- A clear and concise description of what you expected to happen. -->
+<!--
+A clear and concise description of what actually happened. If an exception occurred, please include a stack trace if available.
+-->
 
-## Actual behaviour
+### Screenshots
 
-<!-- A clear and concise description of what actually happened. If an exception occurred, please include a stack trace if available. -->
+<!--
+If applicable, add screenshots to help explain your problem.
+-->
 
-## Screenshots
+### System information
 
-<!-- If applicable, add screenshots to help explain your problem. -->
+<!--
+ - OS: [e.g. Windows 11]
+ - Library Version [e.g. 4.0.0]
+ - SQL LocalDB version [e.g. Microsoft SQL Server 2019 (15.0.4382.1)]
+ - .NET version (e.g. output from `dotnet --info`)
+-->
 
-## System information
+### Additional context
 
-- OS: [e.g. Windows 11]
-- Library Version [e.g. 3.4.0]
-- SQL LocalDB version [e.g. 13.0]
-- .NET version (e.g. output from `dotnet --info`)
-
-## Additional context
-
-<!-- Add any other context about the problem here. -->
+<!--
+Add any other context about the problem here.
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Contact me
+    url: https://martincostello.com/bluesky
+    about: You can also contact me on Bluesky.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,27 +1,30 @@
 ---
 name: Feature request
 about: Suggest an idea for a feature of this library
-title: ''
+title: '[feature] '
 labels: question
-assignees: ''
 ---
 
+### Is your feature request related to a problem?
+
 <!--
-  This is a template. Feel free to delete any sections that are not relevant.
- -->
+A clear and concise description of what the problem is. For example: _It would be useful if [...]_
+-->
 
-## Is your feature request related to a problem?
+### Describe the solution you'd like
 
-<!-- A clear and concise description of what the problem is. For example: _I'm always frustrated when [...]_ -->
+<!--
+A clear and concise description of what you would like to happen.
+-->
 
-## Describe the solution you'd like
+### Describe alternatives you've considered
 
-<!-- A clear and concise description of what you want to happen. -->
+<!--
+A clear and concise description of any alternative solutions or features you've considered.
+-->
 
-## Describe alternatives you've considered
+### Additional context
 
-<!-- A clear and concise description of any alternative solutions or features you've considered. -->
-
-## Additional context
-
-<!-- Add any other context or screenshots about the feature request here. -->
+<!--
+Add any other context or screenshots about the feature request here.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,7 @@
-<!-- Summarise the changes this Pull Request makes. -->
+<!--
 
-<!-- Please include a reference to a GitHub issue if appropriate. -->
+Summarise the changes this Pull Request makes.
+
+Please include a reference to a GitHub issue if appropriate.
+
+-->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,4 +23,3 @@ updates:
   open-pull-requests-limit: 99
   ignore:
     - dependency-name: "Microsoft.Extensions.DependencyInjection.Abstractions"
-    - dependency-name: "Microsoft.Win32.Registry"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,3 +248,13 @@ Added overloads to support specifying the name of the Initial Catalog using the 
   `netstandard2.0`/`net6.0` and `5.1.5` for `net8.0` to include fixes for
   [CVE-2024-0056](https://github.com/advisories/GHSA-98g6-xh36-x2p7).
 * Use interop methods that are compatible with .NET native AoT.
+
+## SqlLocalDb v4.0.0
+
+### Changes
+
+* Update Microsoft.Data.SqlClient dependency to
+  [6.0.2](https://github.com/dotnet/SqlClient/releases/tag/v6.0.2).
+* Drop support for `netstandard2.0` and `net6.0`.
+* Add support for `net472`.
+* Set `IsAotCompatible=true` for `net8.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,5 +256,5 @@ Added overloads to support specifying the name of the Initial Catalog using the 
 * Update Microsoft.Data.SqlClient dependency to
   [6.0.2](https://github.com/dotnet/SqlClient/releases/tag/v6.0.2).
 * Drop support for `netstandard2.0` and `net6.0`.
-* Add support for `net472`.
+* Add support for `net462`.
 * Set `IsAotCompatible=true` for `net8.0`.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team [through a GitHub issue](https://github.com/martincostello/sqllocaldb/issues). All
+reported by contacting the project team [through a GitHub issue][issues]. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
@@ -71,4 +71,5 @@ This Code of Conduct is adapted from the [Contributor Covenant][homepage], versi
 available at [https://contributor-covenant.org/version/1/4][version]
 
 [homepage]: https://contributor-covenant.org
+[issues]: https://github.com/martincostello/sqllocaldb/issues
 [version]: https://contributor-covenant.org/version/1/4/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <UseDefaultAssemblyOriginatorKeyFile>true</UseDefaultAssemblyOriginatorKeyFile>
     <PackageValidationBaselineVersion>3.4.0</PackageValidationBaselineVersion>
-    <VersionPrefix>3.4.1</VersionPrefix>
+    <VersionPrefix>4.0.0</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(EnableReferenceTrimmer)' != 'false' and '$(GenerateDocumentationFile)' != 'true' ">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,16 +11,13 @@
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.5.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.0.2" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageVersion Include="Microsoft.Win32.Registry" Version="4.7.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="ReportGenerator" Version="5.4.5" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />

--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2012-2017 Martin Costello
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/package-readme.md
+++ b/package-readme.md
@@ -1,6 +1,6 @@
 # SQL LocalDB Wrapper
 
-SQL LocalDB Wrapper is a .NET library providing interop with the [Microsoft SQL Server LocalDB](https://docs.microsoft.com/en-us/sql/relational-databases/express-localdb-instance-apis/sql-server-express-localdb-reference-instance-apis?view=sql-server-2017 "SQL Server Express LocalDB Reference - Instance APIs") Instance API from managed code using .NET APIs. The library targets `netstandard2.0`, `net6.0` and `net8.0`.
+SQL LocalDB Wrapper is a .NET library providing interop with the [Microsoft SQL Server LocalDB](https://docs.microsoft.com/en-us/sql/relational-databases/express-localdb-instance-apis/sql-server-express-localdb-reference-instance-apis?view=sql-server-2017 "SQL Server Express LocalDB Reference - Instance APIs") Instance API from managed code using .NET APIs. The library targets `net8.0` and `net472`.
 
 [![NuGet](https://img.shields.io/nuget/v/MartinCostello.SqlLocalDb?logo=nuget&label=Latest&color=blue)](https://www.nuget.org/packages/MartinCostello.SqlLocalDb "Download MartinCostello.SqlLocalDb from NuGet")
 [![NuGet Downloads](https://img.shields.io/nuget/dt/MartinCostello.SqlLocalDb?logo=nuget&label=Downloads&color=blue)](https://www.nuget.org/packages/MartinCostello.SqlLocalDb "Download MartinCostello.SqlLocalDb from NuGet")
@@ -12,7 +12,7 @@ SQL LocalDB Wrapper is a .NET library providing interop with the [Microsoft SQL 
 
 This library exposes types that wrap the native SQL LocalDB Instance API to perform operations on SQL LocalDB such as for managing instances (create, delete, start, stop) and obtaining SQL connection strings for existing instances.
 
-Microsoft SQL Server LocalDB 2012 and later is supported for both x86 and x64 on Microsoft Windows and the library targets `netstandard2.0`.
+Microsoft SQL Server LocalDB 2012 and later is supported for both x86 and x64 on Microsoft Windows.
 
 While the library can be compiled and referenced in .NET applications on non-Windows Operating Systems, SQL LocalDB is only supported on Windows. Non-Windows Operating Systems can query to determine that the SQL LocalDB Instance API is not installed, but other usage will cause a `PlatformNotSupportedException` to be thrown.
 

--- a/package-readme.md
+++ b/package-readme.md
@@ -9,7 +9,7 @@ SQL LocalDB Wrapper is a .NET library providing interop with the
 [![Build status][build-badge]][build-status]
 [![codecov][coverage-badge]][coverage-report]
 
-## IntroductionW
+## Introduction
 
 This library exposes types that wrap the native SQL LocalDB Instance API to perform operations on
 SQL LocalDB such as for managing instances (create, delete, start, stop) and obtaining SQL

--- a/package-readme.md
+++ b/package-readme.md
@@ -1,25 +1,32 @@
 # SQL LocalDB Wrapper
 
-SQL LocalDB Wrapper is a .NET library providing interop with the [Microsoft SQL Server LocalDB](https://docs.microsoft.com/en-us/sql/relational-databases/express-localdb-instance-apis/sql-server-express-localdb-reference-instance-apis?view=sql-server-2017 "SQL Server Express LocalDB Reference - Instance APIs") Instance API from managed code using .NET APIs. The library targets `net8.0` and `net472`.
+SQL LocalDB Wrapper is a .NET library providing interop with the
+[Microsoft SQL Server LocalDB][sqllocaldb] Instance API from managed code using .NET APIs.
 
-[![NuGet](https://img.shields.io/nuget/v/MartinCostello.SqlLocalDb?logo=nuget&label=Latest&color=blue)](https://www.nuget.org/packages/MartinCostello.SqlLocalDb "Download MartinCostello.SqlLocalDb from NuGet")
-[![NuGet Downloads](https://img.shields.io/nuget/dt/MartinCostello.SqlLocalDb?logo=nuget&label=Downloads&color=blue)](https://www.nuget.org/packages/MartinCostello.SqlLocalDb "Download MartinCostello.SqlLocalDb from NuGet")
+[![NuGet][package-badge-version]][package-download]
+[![NuGet Downloads][package-badge-downloads]][package-download]
 
-[![Build status](https://github.com/martincostello/sqllocaldb/actions/workflows/build.yml/badge.svg?branch=main&event=push)](https://github.com/martincostello/sqllocaldb/actions/workflows/build.yml?query=branch%3Amain+event%3Apush)
-[![codecov](https://codecov.io/gh/martincostello/sqllocaldb/branch/main/graph/badge.svg)](https://codecov.io/gh/martincostello/sqllocaldb)
+[![Build status][build-badge]][build-status]
+[![codecov][coverage-badge]][coverage-report]
 
-## Introduction
+## IntroductionW
 
-This library exposes types that wrap the native SQL LocalDB Instance API to perform operations on SQL LocalDB such as for managing instances (create, delete, start, stop) and obtaining SQL connection strings for existing instances.
+This library exposes types that wrap the native SQL LocalDB Instance API to perform operations on
+SQL LocalDB such as for managing instances (create, delete, start, stop) and obtaining SQL
+connection strings for existing instances.
 
 Microsoft SQL Server LocalDB 2012 and later is supported for both x86 and x64 on Microsoft Windows.
 
-While the library can be compiled and referenced in .NET applications on non-Windows Operating Systems, SQL LocalDB is only supported on Windows. Non-Windows Operating Systems can query to determine that the SQL LocalDB Instance API is not installed, but other usage will cause a `PlatformNotSupportedException` to be thrown.
+While the library can be compiled and referenced in .NET applications on non-Windows operating
+systems, SQL LocalDB is only supported on Windows. Non-Windows Operating Systems can query to
+determine that the SQL LocalDB Instance API is not installed, but other usage will cause a
+`PlatformNotSupportedException` to be thrown.
 
 ### Basic Example
 
 ```csharp
-// using MartinCostello.SqlLocalDb;
+using MartinCostello.SqlLocalDb;
+
 using var localDB = new SqlLocalDbApi();
 
 ISqlLocalDbInstanceInfo instance = localDB.GetOrCreateInstance("MyInstance");
@@ -34,13 +41,25 @@ using SqlConnection connection = instance.CreateConnection();
 connection.Open();
 
 // Use the SQL connection...
+
 manager.Stop();
 ```
 
 ## Feedback
 
-Any feedback or issues for this package can be added to the issues in [GitHub](https://github.com/martincostello/sqllocaldb/issues "Issues for this project on GitHub.com").
+Any feedback or issues for this package can be added to the issues in [GitHub][issues].
 
 ## License
 
-This package is licensed under the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt "The Apache 2.0 license") license.
+This package is licensed under the [Apache 2.0][license] license.
+
+[build-badge]: https://github.com/martincostello/sqllocaldb/actions/workflows/build.yml/badge.svg?branch=main&event=push
+[build-status]: https://github.com/martincostello/sqllocaldb/actions/workflows/build.yml?query=branch%3Amain+event%3Apush "Continuous Integration for this project"
+[coverage-badge]: https://codecov.io/gh/martincostello/sqllocaldb/branch/main/graph/badge.svg
+[coverage-report]: https://codecov.io/gh/martincostello/sqllocaldb "Code coverage report for this project"
+[issues]: https://github.com/martincostello/sqllocaldb/issues "Issues for this project on GitHub.com"
+[license]: https://www.apache.org/licenses/LICENSE-2.0.txt "The Apache 2.0 license"
+[package-badge-downloads]: https://img.shields.io/nuget/dt/MartinCostello.SqlLocalDb?logo=nuget&label=Downloads&color=blue
+[package-badge-version]: https://img.shields.io/nuget/v/MartinCostello.SqlLocalDb?logo=nuget&label=Latest&color=blue
+[package-download]: https://www.nuget.org/packages/MartinCostello.SqlLocalDb "Download MartinCostello.SqlLocalDb from NuGet"
+[sqllocaldb]: https://learn.microsoft.com/sql/relational-databases/express-localdb-instance-apis/sql-server-express-localdb-reference-instance-apis "SQL Server Express LocalDB Reference - Instance APIs"

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # SQL LocalDB Wrapper
 
-SQL LocalDB Wrapper is a .NET library providing interop with the [Microsoft SQL Server LocalDB](https://docs.microsoft.com/en-us/sql/relational-databases/express-localdb-instance-apis/sql-server-express-localdb-reference-instance-apis?view=sql-server-2017 "SQL Server Express LocalDB Reference - Instance APIs") Instance API from managed code using .NET APIs. The library targets `netstandard2.0`, `net6.0` and `net8.0`.
+SQL LocalDB Wrapper is a .NET library providing interop with the [Microsoft SQL Server LocalDB](https://docs.microsoft.com/en-us/sql/relational-databases/express-localdb-instance-apis/sql-server-express-localdb-reference-instance-apis?view=sql-server-2017 "SQL Server Express LocalDB Reference - Instance APIs") Instance API from managed code using .NET APIs. The library targets `net8.0` and `net472`.
 
 [![NuGet](https://img.shields.io/nuget/v/MartinCostello.SqlLocalDb?logo=nuget&label=Latest&color=blue)](https://www.nuget.org/packages/MartinCostello.SqlLocalDb "Download MartinCostello.SqlLocalDb from NuGet")
 [![NuGet Downloads](https://img.shields.io/nuget/dt/MartinCostello.SqlLocalDb?logo=nuget&label=Downloads&color=blue)](https://www.nuget.org/packages/MartinCostello.SqlLocalDb "Download MartinCostello.SqlLocalDb from NuGet")
@@ -13,7 +13,7 @@ SQL LocalDB Wrapper is a .NET library providing interop with the [Microsoft SQL 
 
 This library exposes types that wrap the native SQL LocalDB Instance API to perform operations on SQL LocalDB such as for managing instances (create, delete, start, stop) and obtaining SQL connection strings for existing instances.
 
-Microsoft SQL Server LocalDB 2012 and later is supported for both x86 and x64 on Microsoft Windows and the library targets `netstandard2.0`.
+Microsoft SQL Server LocalDB 2012 and later is supported for both x86 and x64 on Microsoft Windows.
 
 While the library can be compiled and referenced in .NET applications on non-Windows Operating Systems, SQL LocalDB is only supported on Windows. Non-Windows Operating Systems can query to determine that the SQL LocalDB Instance API is not installed, but other usage will cause a `PlatformNotSupportedException` to be thrown.
 

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ Further examples of using the library can be found by following the links below:
 ## Migrating from System.Data.SqlLocalDb 1.x
 
 Version `1.x.x` of this library was previously published as [`System.Data.SqlLocalDb`][legacy-package].
-Subsequent versions (`3.x.x` and later) have been renamed and is a breaking change to the previous
+Subsequent versions (`2.x.x` and later) have been renamed and is a breaking change to the previous
 versions, with various changes to namespaces and types.
 
 ## Migrating from MartinCostello.SqlLocalDb 2.x

--- a/readme.md
+++ b/readme.md
@@ -1,34 +1,41 @@
 # SQL LocalDB Wrapper
 
-SQL LocalDB Wrapper is a .NET library providing interop with the [Microsoft SQL Server LocalDB](https://docs.microsoft.com/en-us/sql/relational-databases/express-localdb-instance-apis/sql-server-express-localdb-reference-instance-apis?view=sql-server-2017 "SQL Server Express LocalDB Reference - Instance APIs") Instance API from managed code using .NET APIs. The library targets `net8.0` and `net472`.
+SQL LocalDB Wrapper is a .NET library providing interop with the
+[Microsoft SQL Server LocalDB][sqllocaldb] Instance API from managed code using .NET APIs.
 
-[![NuGet](https://img.shields.io/nuget/v/MartinCostello.SqlLocalDb?logo=nuget&label=Latest&color=blue)](https://www.nuget.org/packages/MartinCostello.SqlLocalDb "Download MartinCostello.SqlLocalDb from NuGet")
-[![NuGet Downloads](https://img.shields.io/nuget/dt/MartinCostello.SqlLocalDb?logo=nuget&label=Downloads&color=blue)](https://www.nuget.org/packages/MartinCostello.SqlLocalDb "Download MartinCostello.SqlLocalDb from NuGet")
+[![NuGet][package-badge-version]][package-download]
+[![NuGet Downloads][package-badge-downloads]][package-download]
 
-[![Build status](https://github.com/martincostello/sqllocaldb/actions/workflows/build.yml/badge.svg?branch=main&event=push)](https://github.com/martincostello/sqllocaldb/actions/workflows/build.yml?query=branch%3Amain+event%3Apush)
-[![codecov](https://codecov.io/gh/martincostello/sqllocaldb/branch/main/graph/badge.svg)](https://codecov.io/gh/martincostello/sqllocaldb)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/martincostello/sqllocaldb/badge)](https://securityscorecards.dev/viewer/?uri=github.com/martincostello/sqllocaldb)
+[![Build status][build-badge]][build-status]
+[![codecov][coverage-badge]][coverage-report]
+[![OpenSSF Scorecard][scorecard-badge]][scorecard-report]
 
 ## Introduction
 
-This library exposes types that wrap the native SQL LocalDB Instance API to perform operations on SQL LocalDB such as for managing instances (create, delete, start, stop) and obtaining SQL connection strings for existing instances.
+This library exposes types that wrap the native SQL LocalDB Instance API to perform operations on
+SQL LocalDB such as for managing instances (create, delete, start, stop) and obtaining SQL
+connection strings for existing instances.
 
 Microsoft SQL Server LocalDB 2012 and later is supported for both x86 and x64 on Microsoft Windows.
 
-While the library can be compiled and referenced in .NET applications on non-Windows Operating Systems, SQL LocalDB is only supported on Windows. Non-Windows Operating Systems can query to determine that the SQL LocalDB Instance API is not installed, but other usage will cause a `PlatformNotSupportedException` to be thrown.
+> [!IMPORTANT]
+> While the library can be compiled and referenced in .NET applications on non-Windows operating
+> systems, SQL LocalDB is only supported on Windows. Non-Windows Operating Systems can query to
+> determine that the SQL LocalDB Instance API is not installed, but other usage will cause a
+> `PlatformNotSupportedException` to be thrown.
 
 ### Installation
 
-To install the library from [NuGet](https://www.nuget.org/packages/MartinCostello.SqlLocalDb/ "MartinCostello.SqlLocalDb on NuGet.org") using the .NET SDK run:
+To install the library from [NuGet][package-download] using the .NET SDK run:
 
-```sh
+```text
 dotnet add package MartinCostello.SqlLocalDb
 ```
 
 ### Basic Example
 
 ```csharp
-// using MartinCostello.SqlLocalDb;
+using MartinCostello.SqlLocalDb;
 
 using var localDB = new SqlLocalDbApi();
 
@@ -52,55 +59,87 @@ manager.Stop();
 
 Further examples of using the library can be found by following the links below:
 
-  1. The [wiki](https://github.com/martincostello/sqllocaldb/wiki/Examples "Examples in the SQL LocalDB Wrapper wiki").
-  1. The [sample application](https://github.com/martincostello/sqllocaldb/tree/main/samples "TodoApp sample").
-  1. The [examples written as tests](https://github.com/martincostello/sqllocaldb/blob/main/tests/SqlLocalDb.Tests/Examples.cs "Examples as tests").
-  1. The library's [own tests](https://github.com/martincostello/sqllocaldb/tree/main/tests/SqlLocalDb.Tests "View MartinCostello.SqlLocalDb's tests").
+1. The [wiki][wiki-examples].
+1. The [sample application][sample-app].
+1. The [examples written as tests][test-examples].
+1. The library's [own tests][tests].
 
 ## Migrating from System.Data.SqlLocalDb 1.x
 
-Version `1.x.x` of this library was previously published as [`System.Data.SqlLocalDb`](https://www.nuget.org/packages/System.Data.SqlLocalDb/ "System.Data.SqlLocalDb on NuGet"). The current version (`3.x.x`) has been renamed and is a breaking change to the previous version with various changes to namespaces and types.
+Version `1.x.x` of this library was previously published as [`System.Data.SqlLocalDb`][legacy-package].
+Subsequent versions (`3.x.x` and later) have been renamed and is a breaking change to the previous
+versions, with various changes to namespaces and types.
 
 ## Migrating from MartinCostello.SqlLocalDb 2.x
 
-Version [`2.x.x`](https://www.nuget.org/packages/MartinCostello.SqlLocalDb/2.0.0 "MartinCostello.SqlLocalDb 2.0.0 on NuGet") of this library uses SQL types from the `System.Data.SqlClient` namespace.
+Version `2.x.x` of this library uses SQL types from the `System.Data.SqlClient` namespace.
 
-The current version (`3.x.x`) uses the new [Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) NuGet package where the same types (such as `SqlConnection`) are now in the `Microsoft.Data.SqlClient` namespace.
+Subsequent versions (`3.x.x` and later) use the new [Microsoft.Data.SqlClient][sqlclient] NuGet package
+where the same types (such as `SqlConnection`) are now in the `Microsoft.Data.SqlClient` namespace.
 
-To migrate a project from using the previous 2.x release, you should change usage of the `System.Data.SqlClient` namespace to `Microsoft.Data.SqlClient` and recompile your project.
+To migrate a project from using the previous `2.x.x` releases, you should change usage of the `System.Data.SqlClient`
+namespace to `Microsoft.Data.SqlClient` and recompile your project.
 
 ## Feedback
 
-Any feedback or issues can be added to the issues for this project in [GitHub](https://github.com/martincostello/sqllocaldb/issues "Issues for this project on GitHub.com").
+Any feedback or issues can be added to the issues for this project in [GitHub][issues].
 
 ## Repository
 
-The repository is hosted in [GitHub](https://github.com/martincostello/sqllocaldb "This project on GitHub.com"): [https://github.com/martincostello/sqllocaldb.git](https://github.com/martincostello/sqllocaldb.git)
+The repository is hosted in [GitHub][repo]: <https://github.com/martincostello/sqllocaldb.git>
 
 ## License
 
-This project is licensed under the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt "The Apache 2.0 license") license.
+This project is licensed under the [Apache 2.0][license] license.
 
 ## Building and Testing
 
-Compiling the library yourself requires Git and the [.NET SDK](https://www.microsoft.com/net/download/core "Download the .NET SDK") to be installed (version `9.0.100` or later).
+Compiling the library yourself requires Git and the latest release of the [.NET SDK][dotnet-sdk] to be installed.
 
-For all of the tests to be functional you must also have at least one version of SQL LocalDB installed.
+For all of the tests to be functional you must also have at least one version of [SQL LocalDB][sqllocaldb] installed.
 
-To build and test the library locally from a terminal/command-line, run the following set of commands:
+To build and test the library locally from a terminal using PowerShell, run the following set of commands:
 
-```powershell
+```text
 git clone https://github.com/martincostello/sqllocaldb.git
 cd sqllocaldb
 ./build.ps1
 ```
 
-**Note**: To run all the tests successfully, you must run either `build.ps1` or Visual Studio with administrative privileges. This is because the SQL LocalDB APIs for sharing LocalDB instances can only be used with administrative privileges. Not running the tests with administrative privileges will cause all tests that exercise such functionality to be skipped.
+> [!NOTE]
+> To run all the tests successfully, you must run either `build.ps1` or Visual Studio with administrative privileges.
+> This is because the SQL LocalDB APIs for sharing LocalDB instances can only be used with administrative privileges.
+> Not running the tests with administrative privileges will cause all tests that exercise such functionality to be skipped.
 
-**Note**: Several tests are skipped on non-Windows Operating Systems as SQL LocalDB itself is only supported on Windows.
+<!-- -->
+
+> [!IMPORTANT]
+> Most tests are skipped on non-Windows Operating Systems as SQL LocalDB itself is only supported on Windows.
 
 ## Copyright and Trademarks
 
-This library is copyright (©) Martin Costello 2012-2024.
+This library is copyright (©) Martin Costello 2012-2025.
 
-[Microsoft SQL Server](https://www.microsoft.com/sql-server/) is a trademark and copyright of the Microsoft Corporation.
+[Microsoft SQL Server][sqlserver] is a trademark and copyright of the Microsoft Corporation.
+
+[build-badge]: https://github.com/martincostello/sqllocaldb/actions/workflows/build.yml/badge.svg?branch=main&event=push
+[build-status]: https://github.com/martincostello/sqllocaldb/actions/workflows/build.yml?query=branch%3Amain+event%3Apush "Continuous Integration for this project"
+[coverage-badge]: https://codecov.io/gh/martincostello/sqllocaldb/branch/main/graph/badge.svg
+[coverage-report]: https://codecov.io/gh/martincostello/sqllocaldb "Code coverage report for this project"
+[dotnet-sdk]: https://dotnet.microsoft.com/download "Download the .NET SDK"
+[issues]: https://github.com/martincostello/sqllocaldb/issues "Issues for this project on GitHub.com"
+[legacy-package]: https://www.nuget.org/packages/System.Data.SqlLocalDb/ "System.Data.SqlLocalDb on NuGet"
+[license]: https://www.apache.org/licenses/LICENSE-2.0.txt "The Apache 2.0 license"
+[package-badge-downloads]: https://img.shields.io/nuget/dt/MartinCostello.SqlLocalDb?logo=nuget&label=Downloads&color=blue
+[package-badge-version]: https://img.shields.io/nuget/v/MartinCostello.SqlLocalDb?logo=nuget&label=Latest&color=blue
+[package-download]: https://www.nuget.org/packages/MartinCostello.SqlLocalDb "Download MartinCostello.SqlLocalDb from NuGet"
+[repo]: https://github.com/martincostello/sqllocaldb "This project on GitHub.com"
+[sample-app]: https://github.com/martincostello/sqllocaldb/tree/main/samples "TodoApp sample"
+[scorecard-badge]: https://api.securityscorecards.dev/projects/github.com/martincostello/sqllocaldb/badge
+[scorecard-report]: https://securityscorecards.dev/viewer/?uri=github.com/martincostello/sqllocaldb "OpenSSF Scorecard for this project"
+[sqlclient]: https://www.nuget.org/packages/Microsoft.Data.SqlClient/ "Microsoft.Data.SqlClient on NuGet"
+[sqllocaldb]: https://learn.microsoft.com/sql/relational-databases/express-localdb-instance-apis/sql-server-express-localdb-reference-instance-apis "SQL Server Express LocalDB Reference - Instance APIs"
+[sqlserver]: https://www.microsoft.com/sql-server/ "Microsoft SQL Server"
+[test-examples]: https://github.com/martincostello/sqllocaldb/blob/main/tests/SqlLocalDb.Tests/Examples.cs "Examples as tests"
+[tests]: https://github.com/martincostello/sqllocaldb/tree/main/tests/SqlLocalDb.Tests "View MartinCostello.SqlLocalDb's tests"
+[wiki-examples]: https://github.com/martincostello/sqllocaldb/wiki/Examples "Examples in the SQL LocalDB Wrapper wiki"

--- a/samples/README.md
+++ b/samples/README.md
@@ -4,16 +4,23 @@ This folder contains a sample application for showing usage of `MartinCostello.S
 
 ## TodoApp
 
-_TodoApp_ is an [ASP.NET](https://learn.microsoft.com/aspnet/core/ "Introduction to ASP.NET") MVC application that uses [Entity Framework Core](https://learn.microsoft.com/ef/core/ "Entity Framework Core") to manage a simple Todo list.
+_TodoApp_ is an [ASP.NET][aspnetcore] MVC application that uses [Entity Framework Core][efcore] to manage a simple Todo list.
 
 The list is stored in a SQL Server database backed by a SQL Server LocalDB Instance on the local machine.
 
-The application is configured to create the LocalDB instance if it does not already exist, start it if necessary, and then [configure the Entity Framework data context](https://github.com/martincostello/sqllocaldb/blob/ef6c1e2918ce084274cbc1e7d173371a7fbaebd3/samples/TodoApp/Startup.cs#L62-L85 "View Startup.cs") with the connection string for the LocalDB instance.
+The application is configured to create the LocalDB instance if it does not already exist, start it if
+necessary, and then [configure the Entity Framework data context][configure] with the connection string for the LocalDB instance.
 
 ## TodoApp.Tests
 
-A test project for the _TodoApp_ application that uses the `TemporarySqlLocalDbInstance` class in `MartinCostello.SqlLocalDb` to [setup a temporary SQL database](https://github.com/martincostello/sqllocaldb/blob/a6c901eec68c05c78ad26eef7c41bc2fc37e564f/samples/TodoApp.Tests/TodoRepositoryTests.cs#L36 "View TodoRepositoryTests.cs") to run functional tests against the TodoApp's data-access logic.
+A test project for the _TodoApp_ application that uses the `TemporarySqlLocalDbInstance` class in `MartinCostello.SqlLocalDb`
+to [setup a temporary SQL database][temporary-instance] to run functional tests against the TodoApp's data-access logic.
 
 The test sets up a test instance, database and schema, then tests the query, create, update and delete functionality of the `TodoRepository` class.
 
 Once the test is run, the test database and LocalDB instance are deleted, also cleaning up the instance's files from the local machine.
+
+[aspnetcore]: https://learn.microsoft.com/aspnet/core/ "Introduction to ASP.NET"
+[efcore]: https://learn.microsoft.com/ef/core/ "Entity Framework Core"
+[configure]: https://github.com/martincostello/sqllocaldb/blob/a3c3a0362e07670e46746430a4102d2cf63ea48b/samples/TodoApp/Program.cs#L19-L42
+[temporary-instance]: https://github.com/martincostello/sqllocaldb/blob/a3c3a0362e07670e46746430a4102d2cf63ea48b/samples/TodoApp.Tests/TodoRepositoryTests.cs#L34

--- a/src/SqlLocalDb/CompatibilitySuppressions.xml
+++ b/src/SqlLocalDb/CompatibilitySuppressions.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>PKV006</DiagnosticId>
+    <Target>.NETStandard,Version=v2.0</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>PKV006</DiagnosticId>
+    <Target>net6.0</Target>
+  </Suppression>
+</Suppressions>

--- a/src/SqlLocalDb/Interop/LocalDbInstanceApi.cs
+++ b/src/SqlLocalDb/Interop/LocalDbInstanceApi.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Text;
 using Microsoft.Extensions.Logging;
 
 namespace MartinCostello.SqlLocalDb.Interop;
@@ -38,7 +37,7 @@ internal sealed class LocalDbInstanceApi : IDisposable
     /// </summary>
     private const int LocalDbTruncateErrorMessage = 1;
 
-#if NETSTANDARD
+#if NETFRAMEWORK
     /// <summary>
     /// An array containing the null character. This field is read-only.
     /// </summary>

--- a/src/SqlLocalDb/Interop/NativeMethods.cs
+++ b/src/SqlLocalDb/Interop/NativeMethods.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2012-2018. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-#if NETSTANDARD
+#if NETFRAMEWORK
 
 using System.Runtime.InteropServices;
 

--- a/src/SqlLocalDb/MartinCostello.SqlLocalDb.csproj
+++ b/src/SqlLocalDb/MartinCostello.SqlLocalDb.csproj
@@ -9,16 +9,12 @@
     <OutputType>Library</OutputType>
     <PackageId>MartinCostello.SqlLocalDb</PackageId>
     <RootNamespace>MartinCostello.SqlLocalDb</RootNamespace>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([System.OperatingSystem]::IsWindows())">$(TargetFrameworks);net472</TargetFrameworks>
     <Title>SQL LocalDB Wrapper</Title>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
-    <EnableAotAnalyzer>true</EnableAotAnalyzer>
-    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
-    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
-    <!-- Mark as AoT compatible when Microsoft.Data.SqlClient and its dependencies are -->
-    <IsAotCompatible>false</IsAotCompatible>
-    <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
   <!--
     Avoid complexity from multi-targeting with conditional compilation.
@@ -32,21 +28,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Data.SqlClient" VersionOverride="2.1.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" VersionOverride="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="2.0.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" VersionOverride="6.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="8.0.2" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
-    <PackageReference Include="Microsoft.Win32.Registry" />
-  </ItemGroup>
-  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
-    <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" VersionOverride="6.0.0" />
-    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" VersionOverride="6.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
-    <PackageReference Update="Microsoft.Data.SqlClient" VersionOverride="5.1.5" />
-    <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" VersionOverride="8.0.0" />
-    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" VersionOverride="8.0.0" />
+  <ItemGroup Condition=" '$([MSBuild]::GetTargetFrameworkIdentifier(`$(TargetFramework)`))' == '.NETFramework' ">
+    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" VersionOverride="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.InteropServices.GuidAttribute">

--- a/src/SqlLocalDb/MartinCostello.SqlLocalDb.csproj
+++ b/src/SqlLocalDb/MartinCostello.SqlLocalDb.csproj
@@ -10,7 +10,7 @@
     <PackageId>MartinCostello.SqlLocalDb</PackageId>
     <RootNamespace>MartinCostello.SqlLocalDb</RootNamespace>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="$([System.OperatingSystem]::IsWindows())">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks Condition="$([System.OperatingSystem]::IsWindows())">$(TargetFrameworks);net462</TargetFrameworks>
     <Title>SQL LocalDB Wrapper</Title>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">

--- a/src/SqlLocalDb/SqlLocalDbException.cs
+++ b/src/SqlLocalDb/SqlLocalDbException.cs
@@ -141,7 +141,7 @@ public class SqlLocalDbException : DbException
     /// The <paramref name="info"/> parameter is <see langword="null"/>.
     /// </exception>
 #pragma warning disable IDE0055
-#if NET8_0_OR_GREATER
+#if NET
     [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
 #endif
 #pragma warning restore IDE0055

--- a/src/SqlLocalDb/TemporarySqlLocalDbInstance.cs
+++ b/src/SqlLocalDb/TemporarySqlLocalDbInstance.cs
@@ -202,7 +202,7 @@ public sealed class TemporarySqlLocalDbInstance : IDisposable, ISqlLocalDbApiAda
     /// </exception>
     private void EnsureNotDisposed()
     {
-#if NET8_0_OR_GREATER
+#if NET
         ObjectDisposedException.ThrowIf(_disposed, this);
 #else
         if (_disposed)

--- a/tests/SqlLocalDb.Tests/MartinCostello.SqlLocalDb.Tests.csproj
+++ b/tests/SqlLocalDb.Tests/MartinCostello.SqlLocalDb.Tests.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="ReportGenerator" />
     <PackageReference Include="Shouldly" />


### PR DESCRIPTION
- Upgrade Microsoft.Data.SqlClient to 6.0.2.
- Drop `netstandard2.0` and `net6.0` targets.
- Add `net462` target.
- Mark `net8.0` target as native AoT compatible.
- Bump version to `4.0.0`.
- Update/modernise documentation.
